### PR TITLE
remove surfaceparm nonsolid in shader light_03

### DIFF
--- a/scripts/fortification.shader
+++ b/scripts/fortification.shader
@@ -207,7 +207,7 @@ textures/fortification/light_03
 	q3map_lightSubdivide 120
 	//q3map_lightRGB	0.58 0.52 0.46
 	q3map_lightmapFilterRadius 0 16
-	surfaceparm nonsolid
+	//surfaceparm nonsolid
 	{
 		map $lightmap
 		rgbGen identity


### PR DESCRIPTION
This shader is used on two rather big surfaces. All classes can fall into the void unless we make these surfaces solid.

Disclaimer: I only tested this in Unvanquished.